### PR TITLE
added wpposts helper for generic query loop

### DIFF
--- a/application/helpers/wp-blade.php
+++ b/application/helpers/wp-blade.php
@@ -5,6 +5,7 @@ class WP_Blade {
 
 	protected static $compilers = array(
 		'wpquery',
+		'wpposts',
 		'wpempty',
 		'wpend',
 		'debug',
@@ -23,6 +24,14 @@ class WP_Blade {
 		}
 
 		return $value;
+	}
+
+	/**
+	 *
+	 */
+	protected static function compile_wpposts( $value ) {
+
+		return str_replace('@wpposts', '<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>', $value);
 	}
 
 	/**


### PR DESCRIPTION
I love the wpquery helper but thought it might be nice to quickly be able to run the generic loop without any params for simple needs. I added in a simple wpposts helper.. thoughts?
