### PR TITLE
Prevent collision when defining global helper functions

### DIFF
--- a/application/helpers/helpers.php
+++ b/application/helpers/helpers.php
@@ -1,43 +1,55 @@
 <?php
-
-function starts_with($haystack, $needles)
+if (!function_exists('starts_with'))
 {
-	foreach ((array) $needles as $needle)
+	function starts_with($haystack, $needles)
 	{
-		if (strpos($haystack, $needle) === 0) return true;
+		foreach ((array) $needles as $needle)
+		{
+			if (strpos($haystack, $needle) === 0) return true;
+		}
+	
+		return false;
 	}
-
-	return false;
 }
 
-function view($view, $data = array()){
-	return Laravel\View::make($view, $data);
-}
-
-/**
- * Determine if a given string contains a given sub-string.
- *
- * @param  string        $haystack
- * @param  string|array  $needle
- * @return bool
- */
-function str_contains($haystack, $needle)
+if (!function_exists('view'))
 {
-	foreach ((array) $needle as $n)
-	{
-		if (strpos($haystack, $n) !== false) return true;
+	function view($view, $data = array()){
+		return Laravel\View::make($view, $data);
 	}
-
-	return false;
 }
 
-
-function queryToArray($args = array()){
-	$query = new WP_Query($args);
-	return $query->get_posts();
+if (!function_exists('str_contains'))
+{
+	/**
+	 * Determine if a given string contains a given sub-string.
+	 *
+	 * @param  string        $haystack
+	 * @param  string|array  $needle
+	 * @return bool
+	 */
+	function str_contains($haystack, $needle)
+	{
+		foreach ((array) $needle as $n)
+		{
+			if (strpos($haystack, $n) !== false) return true;
+		}
+	
+		return false;
+	}
 }
 
+if (!function_exists('queryToArray'))
+{
+	function queryToArray($args = array()){
+		$query = new WP_Query($args);
+		return $query->get_posts();
+	}
+}
 
-function blade_set_storage_path($path){
-	$GLOBALS[ 'blade_storage_path' ] = $path;
+if (!function_exists('blade_set_storage_path'))
+{
+	function blade_set_storage_path($path){
+		$GLOBALS[ 'blade_storage_path' ] = $path;
+	}
 }


### PR DESCRIPTION
I'm using your package as part of a big project which also includes the whole Laravel framework. I know this sounds weird... Anyway when defining the global functions in helpers.php, some of the collide with Laravel's global functions. The fix is to check if they exist before defining them, the same way Laravel's original code does for itself.
